### PR TITLE
Fix: Convert string to number for Intl.NumberFormat

### DIFF
--- a/src/components/Counter.tsx
+++ b/src/components/Counter.tsx
@@ -27,7 +27,7 @@ export default function Counter({
       springValue.on("change", (latest) => {
         if (ref.current) {
           ref.current.textContent = Intl.NumberFormat("en-US").format(
-            latest.toFixed(0)
+            Number(latest.toFixed(0))
           )
         }
       }),


### PR DESCRIPTION
Error occured because latest.toFixed(0) returns a string, but Intl.NumberFormat().format expects a number. This converts the string returned by toFixed(0) back to a number before passing it to Intl.NumberFormat().format. cc @bapspatil 